### PR TITLE
saved calc time if all tiles are equally connected

### DIFF
--- a/src/search/graph.rs
+++ b/src/search/graph.rs
@@ -217,7 +217,7 @@ mod test {
         let you = board.snakes[0].clone();
         let game_board = board.to_game_board();
 
-        let path = bfs(&board, &mut game_board, &you, 0.5);
+        let path = bfs(&board, &game_board, &you, 0.5);
         assert!(path.len() > 0 && path[path.len() - 1] == types::Coord { x: 8, y: 4 });
 
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -115,6 +115,11 @@ impl PartialEq for Battlesnake {
 //         }
 //     }
 // }
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct IndexedCoord{
+    pub coord: Coord,
+    pub connected_index: f32
+}
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub struct Coord {


### PR DESCRIPTION
- if snake is adjacent to 3 tiles it was always calculating the connectivity of the tiles, I changed the functionality to only calculate the connectedness if a path diverges
- added some styling to the snake